### PR TITLE
Fix main page documentation lists layout

### DIFF
--- a/documentation/README.md
+++ b/documentation/README.md
@@ -4,12 +4,14 @@
 ClickHaskell is a Haskell implementation of [ClickHouse](https://clickhouse.com/) DBMS client
 
 ClickHaskell provides for users:
+
 1. Type safe developer-friendly interface
 2. Always up-to-date [documentation](https://kovalevdima.github.io/ClickHaskell/)
 3. End-to-end tests before distribution
 4. Very low dependency footprint
 
 ClickHaskell provides for contributors:
+
 1. Reproducable and complete dev environment
 2. Documnetation autogeneration
 3. Easy to run profiling environment


### PR DESCRIPTION
Now:
![image](https://github.com/user-attachments/assets/462b7ccb-51ed-4234-92b6-451cad800f27)
Should be:
![image](https://github.com/user-attachments/assets/17b2f95b-21a3-4942-900e-dad103e11f51)
