### PR TITLE
Add streaming selects + handling 1 billion rows profiler

### DIFF
--- a/profiling/OneBillionStream.hs
+++ b/profiling/OneBillionStream.hs
@@ -52,13 +52,7 @@ main = do
       connection
       (toChType $
       "SELECT * FROM generateRandom('\
-      \a1 Int64, \
-      \a2 String, \
-      \a3 DateTime, \
-      \a4 UUID, \
-      \a5 Int32, \
-      \a6 Nullable(String), \
-      \a7 String \
+      \a1 Int64 \
       \', 1, 10, 2) LIMIT " <> (string8 . show) totalRows)
       (\records -> pure $!! [length records])
   print result
@@ -70,12 +64,6 @@ main = do
 
 data ExampleData = MkExampleData
   { a1 :: ChInt64
-  , a2 :: StrictByteString
-  , a3 :: Word32
-  , a4 :: ChUUID
-  , a5 :: Int32
-  , a6 :: Nullable ChString
-  , a7 :: ChString
   }
   deriving (Generic, Show, NFData)
   deriving anyclass (ReadableFrom (Columns ExampleColumns), WritableInto (Table "oneBillionStream" ExampleColumns))
@@ -83,10 +71,4 @@ data ExampleData = MkExampleData
 
 type ExampleColumns =
  '[ Column "a1" ChInt64
-  , Column "a2" ChString
-  , Column "a3" ChDateTime
-  , Column "a4" ChUUID
-  , Column "a5" ChInt32
-  , Column "a6" (Nullable ChString)
-  , Column "a7" ChString
   ]

--- a/profiling/profilers.cabal
+++ b/profiling/profilers.cabal
@@ -18,6 +18,20 @@ source-repository head
   location: https://github.com/KovalevDima/ClickHaskell
   subdir: dev
 
+common dump-core
+  ghc-options:
+    -ddump-to-file
+    -ddump-simpl
+    -dsuppress-type-applications
+    -dsuppress-coercions
+    -dsuppress-idinfo
+    -dsuppress-type-signatures
+    -dsuppress-var-kinds
+    -dsuppress-module-prefixes
+    -dsuppress-uniques
+    -ddump-simpl-stats
+    -ddump-rule-firings
+
 Flag dev
   Description: Dump core
   Manual: True
@@ -30,22 +44,11 @@ executable profiler
     -O2
     -threaded
     -main-is Profiler
-    -- * Dump core
-    -ddump-to-file
-    -ddump-simpl
-    -dsuppress-type-applications
-    -dsuppress-coercions
-    -dsuppress-idinfo
-    -dsuppress-type-signatures
-    -dsuppress-var-kinds
-    -dsuppress-module-prefixes
-    -dsuppress-uniques
-    -ddump-simpl-stats
-    -ddump-rule-firings
-
+    -Wall -Wunused-packages
   ghc-prof-options:
     -fprof-late
     -rtsopts "-with-rtsopts=-s -A32m -AL256m -p -hy -L250 -l-agu -N1"
+  import: dump-core
 
   build-depends:
     -- Internal
@@ -54,10 +57,6 @@ executable profiler
     -- GHC included
     , base
     , bytestring
-    , deepseq
-    , stm
-    , time
-    , template-haskell
 
 executable one-billion-stream
   main-is: OneBillionStream.hs
@@ -66,22 +65,11 @@ executable one-billion-stream
     -O2
     -threaded
     -main-is OneBillionStream
-    -- * Dump core
-    -ddump-to-file
-    -ddump-simpl
-    -dsuppress-type-applications
-    -dsuppress-coercions
-    -dsuppress-idinfo
-    -dsuppress-type-signatures
-    -dsuppress-var-kinds
-    -dsuppress-module-prefixes
-    -dsuppress-uniques
-    -ddump-simpl-stats
-    -ddump-rule-firings
-
+    -Wall -Wunused-packages
   ghc-prof-options:
     -fprof-late
     -rtsopts "-with-rtsopts=-s -A8m -AL256m -p -hy -L250 -l-agu -N1"
+  import: dump-core
 
   build-depends:
     -- Internal
@@ -91,6 +79,3 @@ executable one-billion-stream
     , base
     , bytestring
     , deepseq
-    , stm
-    , time
-    , template-haskell

--- a/profiling/profilers.cabal
+++ b/profiling/profilers.cabal
@@ -54,6 +54,43 @@ executable profiler
     -- GHC included
     , base
     , bytestring
+    , deepseq
+    , stm
+    , time
+    , template-haskell
+
+executable one-billion-stream
+  main-is: OneBillionStream.hs
+  hs-source-dirs: ./
+  ghc-options:
+    -O2
+    -threaded
+    -main-is OneBillionStream
+    -- * Dump core
+    -ddump-to-file
+    -ddump-simpl
+    -dsuppress-type-applications
+    -dsuppress-coercions
+    -dsuppress-idinfo
+    -dsuppress-type-signatures
+    -dsuppress-var-kinds
+    -dsuppress-module-prefixes
+    -dsuppress-uniques
+    -ddump-simpl-stats
+    -ddump-rule-firings
+
+  ghc-prof-options:
+    -fprof-late
+    -rtsopts "-with-rtsopts=-s -A8m -AL256m -p -hy -L250 -l-agu -N1"
+
+  build-depends:
+    -- Internal
+      ClickHaskell
+
+    -- GHC included
+    , base
+    , bytestring
+    , deepseq
     , stm
     , time
     , template-haskell


### PR DESCRIPTION
Current solution are able to handle 1 billion rows in constant 50mb peak memory usage
It takes ~13min on single core profiling runtime on my Ryzen 9 5950x

![image](https://github.com/user-attachments/assets/6be4d1fb-e0d6-47f5-9452-e19d06e55bff)
