### PR TITLE
Optimize columns deserialization

### DIFF
--- a/distribution/ClickHaskell/NativeProtocol.hs
+++ b/distribution/ClickHaskell/NativeProtocol.hs
@@ -463,7 +463,11 @@ class
   where
   default deserializeColumns :: GenericReadable record hasColumns => ProtocolRevision -> UVarInt -> Get [record]
   deserializeColumns :: ProtocolRevision -> UVarInt -> Get [record]
-  deserializeColumns rev size = map to <$> gFromColumns @(GetColumns hasColumns) rev size
+  deserializeColumns rev size = do
+    list <- gFromColumns @(GetColumns hasColumns) rev size
+    pure $ do
+      element <- list
+      case to element of res -> pure $! res
 
   default readingColumns :: GenericReadable record hasColumns => Builder
   readingColumns :: Builder


### PR DESCRIPTION
# Before
```
"Writing done. 1000000 rows was written"
   4,241,649,520 bytes allocated in the heap
   3,575,929,432 bytes copied during GC
     403,290,768 bytes maximum residency (15 sample(s))
      21,316,528 bytes maximum slop
            1159 MiB total memory in use (0 MiB lost due to fragmentation)

                                     Tot time (elapsed)  Avg pause  Max pause
  Gen  0       977 colls,     0 par    8.513s   8.516s     0.0087s    0.0196s
  Gen  1        15 colls,     0 par    5.884s   5.884s     0.3923s    1.4575s

  TASKS: 4 (1 bound, 3 peak workers (3 total), using -N1)

  SPARKS: 0 (0 converted, 0 overflowed, 0 dud, 0 GC'd, 0 fizzled)

  INIT    time    0.000s  (  0.000s elapsed)
  MUT     time    0.987s  (  2.609s elapsed)
  GC      time   14.397s  ( 14.400s elapsed)
  EXIT    time    0.000s  (  0.000s elapsed)
  Total   time   15.385s  ( 17.010s elapsed)

  Alloc rate    4,296,224,002 bytes per MUT second

  Productivity   6.4% of total user, 15.3% of total elapsed
```

# After
```
   4,202,135,624 bytes allocated in the heap
   3,439,889,824 bytes copied during GC
     383,454,544 bytes maximum residency (15 sample(s))
      21,526,688 bytes maximum slop
            1088 MiB total memory in use (0 MiB lost due to fragmentation)

                                     Tot time (elapsed)  Avg pause  Max pause
  Gen  0       967 colls,     0 par    8.037s   8.040s     0.0083s    0.0190s
  Gen  1        15 colls,     0 par    5.585s   5.585s     0.3724s    1.3379s

  TASKS: 4 (1 bound, 3 peak workers (3 total), using -N1)

  SPARKS: 0 (0 converted, 0 overflowed, 0 dud, 0 GC'd, 0 fizzled)

  INIT    time    0.000s  (  0.000s elapsed)
  MUT     time    0.921s  (  2.552s elapsed)
  GC      time   13.623s  ( 13.625s elapsed)
  EXIT    time    0.000s  (  0.002s elapsed)
  Total   time   14.544s  ( 16.180s elapsed)

  Alloc rate    4,563,952,293 bytes per MUT second

  Productivity   6.3% of total user, 15.8% of total elapsed
```