### PR TITLE
Optimize UUID deserialization

### DIFF
--- a/distribution/ClickHaskell/NativeProtocol.hs
+++ b/distribution/ClickHaskell/NativeProtocol.hs
@@ -23,7 +23,7 @@ import Paths_ClickHaskell (version)
 import Data.Text (Text)
 import Data.Version (Version (..))
 import Data.String (IsString(..))
-import Control.Monad (forM, replicateM)
+import Control.Monad (forM, replicateM, (<$!>))
 import Data.Binary.Get
 import Data.Binary.Get.Internal (readN)
 import Data.Binary.Put
@@ -689,7 +689,7 @@ instance
 -- ** Database types
 
 instance Deserializable ChUUID where
-  deserialize _ = MkChUUID <$> (flip Word128 <$> getWord64le <*> getWord64le)
+  deserialize _ = MkChUUID <$!> (flip Word128 <$> getWord64le <*> getWord64le)
 
 instance Deserializable ChString where
   deserialize rev = do


### PR DESCRIPTION
Achieved by getting rid of excess thunk
16Mb(ChUUID)+32Mb(Word128) turned into 24Mb(Word128) 

# Before
```
"Writing done. 1000000 rows was written"
   4,203,532,584 bytes allocated in the heap
   3,439,815,912 bytes copied during GC
     383,457,208 bytes maximum residency (15 sample(s))
      21,507,760 bytes maximum slop
            1089 MiB total memory in use (0 MiB lost due to fragmentation)

                                     Tot time (elapsed)  Avg pause  Max pause
  Gen  0       967 colls,     0 par    8.534s   8.543s     0.0088s    0.0309s
  Gen  1        15 colls,     0 par    5.836s   5.844s     0.3896s    1.4395s

  TASKS: 4 (1 bound, 3 peak workers (3 total), using -N1)

  SPARKS: 0 (0 converted, 0 overflowed, 0 dud, 0 GC'd, 0 fizzled)

  INIT    time    0.000s  (  0.000s elapsed)
  MUT     time    0.970s  (  2.591s elapsed)
  GC      time   14.370s  ( 14.386s elapsed)
  EXIT    time    0.001s  (  0.004s elapsed)
  Total   time   15.341s  ( 16.981s elapsed)

  Alloc rate    4,334,254,506 bytes per MUT second

  Productivity   6.3% of total user, 15.3% of total elapsed
```

# After
```
"Writing done. 1000000 rows was written"
   4,170,250,728 bytes allocated in the heap
   3,297,819,688 bytes copied during GC
     359,457,904 bytes maximum residency (15 sample(s))
      24,475,208 bytes maximum slop
            1021 MiB total memory in use (0 MiB lost due to fragmentation)

                                     Tot time (elapsed)  Avg pause  Max pause
  Gen  0       958 colls,     0 par    7.932s   7.942s     0.0083s    0.0313s
  Gen  1        15 colls,     0 par    5.503s   5.509s     0.3673s    1.2652s

  TASKS: 4 (1 bound, 3 peak workers (3 total), using -N1)

  SPARKS: 0 (0 converted, 0 overflowed, 0 dud, 0 GC'd, 0 fizzled)

  INIT    time    0.000s  (  0.000s elapsed)
  MUT     time    0.980s  (  2.586s elapsed)
  GC      time   13.436s  ( 13.451s elapsed)
  EXIT    time    0.000s  (  0.002s elapsed)
  Total   time   14.416s  ( 16.040s elapsed)

  Alloc rate    4,254,295,957 bytes per MUT second

  Productivity   6.8% of total user, 16.1% of total elapsed
```