### PR TITLE
Move TLS support to a separate package

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -1,5 +1,6 @@
 packages:
     ./library
+    ./library/tls
     ./contribution/html2hs
     ./contribution/server
     ./contribution/modules/eventlog-writer

--- a/contribution/modules/eventlog-writer/eventlog-agent.hs
+++ b/contribution/modules/eventlog-writer/eventlog-agent.hs
@@ -14,7 +14,7 @@
 
 module Main (main) where
 
-import ClickHaskell
+import ClickHaskell hiding (Buffer(..), initBuffer)
 import Control.Concurrent (threadDelay)
 import Control.Concurrent.Async (Concurrently (..))
 import Control.Concurrent.STM (TBQueue, atomically, flushTBQueue, newTBQueueIO, writeTBQueue)

--- a/documentation/testing/index.lhs
+++ b/documentation/testing/index.lhs
@@ -49,22 +49,11 @@ You can manually run database and tests:
 <h2>Main function</h2>
 
 <pre><code data-lang="haskell" class="haskell"
->import ClickHaskell (openConnection, defaultConnectionArgs, overrideTLS)
-import Network.TLS (defaultParamsClient, ClientParams (..), Shared (..), ValidationCache (..), ValidationCacheResult (..))
-import Data.Default.Class 
+>import ClickHaskell (openConnection, defaultConnectionArgs)
 
 main :: IO ()
 main = do
-  connection <- openConnection
-    . overrideTLS (defaultParamsClient "localhost" "9440")
-        { clientShared = def
-          { sharedValidationCache =
-              ValidationCache
-                (\_ _ _ -> return ValidationCachePass)
-                (\_ _ _ -> return ())
-          }
-        }
-    $ defaultConnectionArgs
+  connection <- openConnection defaultConnectionArgs
   mapM_
     (\runner -> runner connection) 
     [t1,t2,t3,t4]

--- a/documentation/testing/tests.cabal
+++ b/documentation/testing/tests.cabal
@@ -16,7 +16,6 @@ executable tests
   build-depends:
       ClickHaskell
     , async
-    , tls
     , data-default-class
     , base >=4.7 && <5
     , bytestring

--- a/library/tls/ChangeLog.md
+++ b/library/tls/ChangeLog.md
@@ -1,0 +1,3 @@
+# 0.1.0 -- ?
+
+Initial release

--- a/library/tls/ClickHaskell-tls.cabal
+++ b/library/tls/ClickHaskell-tls.cabal
@@ -1,14 +1,14 @@
 Cabal-version: 3.0
 
 
-Name:           ClickHaskell
+Name:           ClickHaskell-tls
 Version:        1.0.0
 
 Author:         Kovalev Dmitry
 Maintainer:     Kovalev Dmitry
 Category:       ClickHouse
-Synopsis:       ClickHouse driver
-Description:    Small dependency footprint highlevel ClickHouse driver 
+Synopsis:       ClickHaskell TLS extension
+Description:    ClickHaskell library extension with provided TLS support 
 Tested-with:    GHC == 8.10.7, GHC == 9.0.2, GHC == 9.2.8, GHC == 9.4.8, GHC == 9.6.6, GHC == 9.8.4, GHC == 9.10.1
 Homepage:       https://clickhaskell.dev/
 Bug-reports:    https://git.clickhaskell.dev/
@@ -18,7 +18,6 @@ Copyright:      2023 Kovalev Dmitry
 Build-Type:     Simple
 
 extra-doc-files:
-  README.md
   ChangeLog.md
 
 Source-repository head
@@ -32,11 +31,11 @@ Flag dev
 
 Library
   Autogen-Modules:
-    Paths_ClickHaskell
+    Paths_ClickHaskell_tls
   Exposed-Modules:
-    ClickHaskell
+    ClickHaskell.TLS
   Other-Modules:
-    Paths_ClickHaskell
+    Paths_ClickHaskell_tls
   HS-Source-Dirs:
     ./
   GHC-Options:
@@ -46,15 +45,13 @@ Library
   Build-depends:
     -- GHC included libraries
       base >= 4.7 && <5
-    , bytestring < 1
-    , binary < 9
-    , deepseq < 2
-    , text < 3
-    , time < 2
 
+    -- Internal
+    , ClickHaskell ^>= 1.0.0
+    
     -- External dependencies
     , network < 4
-    , wide-word < 1
+    , tls < 3
 
   if flag(dev)
     GHC-Options:
@@ -68,29 +65,6 @@ Library
 
   default-language: Haskell2010
   default-extensions:
-    AllowAmbiguousTypes
-    ConstraintKinds
-    DataKinds
-    DefaultSignatures
-    DeriveAnyClass
-    DeriveGeneric
-    DerivingStrategies
-    DuplicateRecordFields
-    GADTs
-    GeneralizedNewtypeDeriving
-    ImportQualifiedPost
-    FlexibleContexts
-    FlexibleInstances
-    LambdaCase
-    MultiParamTypeClasses
     NamedFieldPuns
-    NumericUnderscores
-    OverloadedStrings
     RecordWildCards
-    TupleSections
-    TypeApplications
-    TypeFamilies
-    TypeOperators
-    ScopedTypeVariables
-    StandaloneDeriving
-    UndecidableInstances
+    OverloadedStrings

--- a/library/tls/ClickHaskell/TLS.hs
+++ b/library/tls/ClickHaskell/TLS.hs
@@ -1,0 +1,39 @@
+module ClickHaskell.TLS where
+
+-- Internal
+import ClickHaskell
+  ( ConnectionArgs(..)
+  , Buffer(..)
+  )
+
+-- GHC included
+import Data.IORef (newIORef)
+
+-- External
+import Network.TLS (ClientParams (..), contextNew, contextClose, sendData, recvData, defaultParamsClient, handshake)
+import Network.Socket as Sock (connect, setSocketOption, SocketOption (..))
+
+{-|
+  Sets TLS connection
+
+  Uses 9443 port by default. Watch 'setPort' to override it
+-}
+setSecure :: (ClientParams -> ClientParams) -> ConnectionArgs -> ConnectionArgs
+setSecure modifyParams MkConnectionArgs{..} =
+  MkConnectionArgs{initBuffer = initTLS, isTLS=True, ..}
+  where
+  initTLS = \hostname addrAddress sock -> do
+    setSocketOption sock Sock.NoDelay 1
+    setSocketOption sock Sock.KeepAlive 1
+    connect sock addrAddress
+    let defClientParams = modifyParams (defaultParamsClient hostname "")
+    context <- contextNew sock defClientParams
+    handshake context
+    buff <- newIORef ""
+    pure
+      MkBuffer
+        { writeSock = \bs -> sendData context bs
+        , readSock  = recvData context
+        , closeSock = contextClose context
+        , buff
+        }

--- a/library/tls/LICENSE
+++ b/library/tls/LICENSE
@@ -1,0 +1,28 @@
+BSD 3-Clause License
+
+Copyright (c) 2025, Dmitry Kovalev
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.


### PR DESCRIPTION
The tls package introduces many dependencies, some of which are not actively supported. The decision to move tls into a separate package was made because not every user needs a TLS connection. Including it in the main package can increase build times for end users and may cause issues when migrating to new versions of GHC in the future